### PR TITLE
Update StreamFactory.cs

### DIFF
--- a/QuickFIXn/Transport/StreamFactory.cs
+++ b/QuickFIXn/Transport/StreamFactory.cs
@@ -350,20 +350,11 @@ namespace QuickFix.Transport
                 if (cert2 == null)
                     cert2 = new X509Certificate2(certificate);
 
-                foreach (X509Extension extension in cert2.Extensions)
-                {
-                    if (extension is X509EnhancedKeyUsageExtension)
-                    {
-                        var keyUsage = (X509EnhancedKeyUsageExtension)extension;
-                        foreach (var oid in keyUsage.EnhancedKeyUsages)
-                        {
-                            if (oid.Value == enhancedKeyOid)
-                                return true;
-                        }
-                    }
-                }
-
-                return false;
+                X509Chain chain = new X509Chain();
+                chain.ChainPolicy.ApplicationPolicy.Add(new System.Security.Cryptography.Oid(enhancedKeyOid));
+                //this method just needs to check usage permissions, everything else is ignored
+                chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllFlags & ~X509VerificationFlags.IgnoreWrongUsage;
+                return chain.Build(cert2);
             }
 
 


### PR DESCRIPTION
Corrects certificate purpose validation. 
Current implementation expects the X509v3 extension "Extended Key Usage: ...." and does not accept the general certificate purposes.
For example:  if a certificate doesn't have explicitly added enhanced key usage but instead has enabled "all purposes" including "Server  Authentication", then an error is returned "Remote certificate is not intended for server authentication: It is missing enhanced key usage ..." even though certificate can be used for Server Authentication.